### PR TITLE
Fillvaluefix

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,23 +1,25 @@
+{% set version = "3.0.9" %}
+
 package:
   name: ipart
-  version: 3.0.9
+  version: {{ version }}
 
 source:
-  url: https://github.com/ihesp/IPART/archive/v3.0.9.tar.gz
+  url: https://github.com/ihesp/IPART/archive/v{{ version }}.tar.gz
   sha256: 77f320d361aa8f2ac85eda77e0c5fc72ff7e4cf7474219076d967007fefb52f4
 
 build:
-  noarch: python>=3
+  noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
   host:
-    - python
+    - python >=3.6
     - setuptools
     - pip
   run:
-    - python
+    - python >=3.6
     - numpy
     - scipy
     - pandas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ source:
   sha256: 77f320d361aa8f2ac85eda77e0c5fc72ff7e4cf7474219076d967007fefb52f4
 
 build:
-  noarch: python
+  noarch: python>=3
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,23 +1,24 @@
+{% set version = "3.0.9" %}
 package:
   name: ipart
-  version: 3.0.9
+  version: {{ version }}
 
 source:
-  url: https://github.com/ihesp/IPART/archive/v3.0.9.tar.gz
+  url: https://github.com/ihesp/IPART/archive/v{{ version }}.tar.gz
   sha256: 77f320d361aa8f2ac85eda77e0c5fc72ff7e4cf7474219076d967007fefb52f4
 
 build:
-  noarch: python>=3
+  noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
   host:
-    - python
+    - python >=3
     - setuptools
     - pip
   run:
-    - python
+    - python >=3
     - numpy
     - scipy
     - pandas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: ipart
-  version: 3.0.7
+  version: 3.0.9
 
 source:
-  url: https://github.com/ihesp/IPART/archive/v3.0.7.tar.gz
-  sha256: b761b414be6145908781b3a0ac6cf45ad8e2fbd8c539c0052e04560f2ace4c23
+  url: https://github.com/ihesp/IPART/archive/v3.0.9.tar.gz
+  sha256: 77f320d361aa8f2ac85eda77e0c5fc72ff7e4cf7474219076d967007fefb52f4
 
 build:
   noarch: python


### PR DESCRIPTION
@conda-forge/staged-recipes
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes https://github.com/ihesp/IPART/issues/18
<!--
Please add any other relevant info below:
-->

Help needed. 
I got this error message from the linux_64_ pipeline:

```
conda.exceptions.InvalidVersionSpec: Invalid version '3.6.* *_cpython': invalid character(s)
```

The conda-forge-linter suggests adding a lower bound on the python version for norach. So I tried `noarch: python>=3`. But this gives me this different error:

```
conda_build.exceptions.CondaBuildException: Invalid value for noarch: python>=3
```
What am I doing wrong?
Thanks